### PR TITLE
Add support for more track types

### DIFF
--- a/lib/CMX3600Parser/CMX3600Parser.js
+++ b/lib/CMX3600Parser/CMX3600Parser.js
@@ -56,7 +56,7 @@ class CMX3600Parser extends Transform {
       recordEnd,
     ] = matches;
 
-    const [, trackType, tn] = /(\w)(\d+)?/.exec(track);
+    const [, trackType, tn] = /([^\d]+)(\d+)?/.exec(track);
 
     this.currentEvent = new Event({
       number: parseInt(number, 10),

--- a/lib/CMX3600Parser/CMX3600Parser.test.js
+++ b/lib/CMX3600Parser/CMX3600Parser.test.js
@@ -31,6 +31,10 @@ function generateAudioEvent() {
   return getBasicStream('004  BFD_CHIL A10   C        01:00:01:05 01:00:02:05 01:00:11:19 01:00:12:19 ');
 }
 
+function generateAudioVideoEvent() {
+  return getBasicStream('004  BFD_CHIL AA/V   C        01:00:01:05 01:00:02:05 01:00:11:19 01:00:12:19 ');
+}
+
 function generateEventWithComments() {
   return getBasicStream([
     '002  EVL1_ESC V     C        06:00:02:01 06:00:07:12 01:00:00:25 01:00:01:16 ',
@@ -113,6 +117,20 @@ describe('CMX3600Parser', () => {
       output.on('end', () => {
         assert.strictEqual(results[0].trackType, 'A');
         assert.strictEqual(results[0].trackNumber, 10);
+
+        done();
+      });
+    });
+
+    it('new Event(CMXstring) should parse audio video tracks', (done) => {
+      const input = generateAudioVideoEvent();
+      const output = new CMX3600Parser();
+      input.pipe(output);
+      const results = [];
+
+      output.on('data', (data) => results.push(data));
+      output.on('end', () => {
+        assert.strictEqual(results[0].trackType, 'AA/V');
 
         done();
       });


### PR DESCRIPTION
CMX3600 files can contain tracktypes that are more than one character long. The official list is 

- A (Audio 1 only)
- B (Audio 1 and video)
- V (Video only)
- A2 (Audio2 only)
- A2/V (Audio2 and video)
- AA (Audio 1 and Audio 2)
- AA/V (Audio 1, Audio 2, Video)

This change adds support for some of these (AA, AA/V), while tracks like A2/V still wont work due to the way the library splits track number out. 